### PR TITLE
Update actions list

### DIFF
--- a/_actions/AddBorder.md
+++ b/_actions/AddBorder.md
@@ -1,8 +1,6 @@
 ---
 title: AddBorder
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the AddBorder action will appear here.
+No details available for `AddBorder`.

--- a/_actions/AddExportFormat.md
+++ b/_actions/AddExportFormat.md
@@ -1,8 +1,6 @@
 ---
 title: AddExportFormat
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the AddExportFormat action will appear here.
+No details available for `AddExportFormat`.

--- a/_actions/AddFill.md
+++ b/_actions/AddFill.md
@@ -1,8 +1,6 @@
 ---
 title: AddFill
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the AddFill action will appear here.
+No details available for `AddFill`.

--- a/_actions/AddFlow.md
+++ b/_actions/AddFlow.md
@@ -1,8 +1,6 @@
 ---
 title: AddFlow
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the AddFlow action will appear here.
+No details available for `AddFlow`.

--- a/_actions/AddFlowBack.md
+++ b/_actions/AddFlowBack.md
@@ -1,8 +1,6 @@
 ---
 title: AddFlowBack
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the AddFlowBack action will appear here.
+No details available for `AddFlowBack`.

--- a/_actions/AddFlowHome.md
+++ b/_actions/AddFlowHome.md
@@ -1,8 +1,6 @@
 ---
 title: AddFlowHome
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the AddFlowHome action will appear here.
+No details available for `AddFlowHome`.

--- a/_actions/AddInnerShadow.md
+++ b/_actions/AddInnerShadow.md
@@ -1,8 +1,6 @@
 ---
 title: AddInnerShadow
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the AddInnerShadow action will appear here.
+No details available for `AddInnerShadow`.

--- a/_actions/AddShadow.md
+++ b/_actions/AddShadow.md
@@ -1,8 +1,6 @@
 ---
 title: AddShadow
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the AddShadow action will appear here.
+No details available for `AddShadow`.

--- a/_actions/AlignBottom.md
+++ b/_actions/AlignBottom.md
@@ -1,8 +1,6 @@
 ---
 title: AlignBottom
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the AlignBottom action will appear here.
+No details available for `AlignBottom`.

--- a/_actions/AlignCenter.md
+++ b/_actions/AlignCenter.md
@@ -1,8 +1,6 @@
 ---
 title: AlignCenter
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the AlignCenter action will appear here.
+No details available for `AlignCenter`.

--- a/_actions/AlignJustified.md
+++ b/_actions/AlignJustified.md
@@ -1,8 +1,6 @@
 ---
 title: AlignJustified
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the AlignJustified action will appear here.
+No details available for `AlignJustified`.

--- a/_actions/AlignLayersBottom.md
+++ b/_actions/AlignLayersBottom.md
@@ -1,8 +1,6 @@
 ---
 title: AlignLayersBottom
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the AlignLayersBottom action will appear here.
+No details available for `AlignLayersBottom`.

--- a/_actions/AlignLayersCenter.md
+++ b/_actions/AlignLayersCenter.md
@@ -1,8 +1,6 @@
 ---
 title: AlignLayersCenter
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the AlignLayersCenter action will appear here.
+No details available for `AlignLayersCenter`.

--- a/_actions/AlignLayersLeft.md
+++ b/_actions/AlignLayersLeft.md
@@ -1,8 +1,6 @@
 ---
 title: AlignLayersLeft
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the AlignLayersLeft action will appear here.
+No details available for `AlignLayersLeft`.

--- a/_actions/AlignLayersMiddle.md
+++ b/_actions/AlignLayersMiddle.md
@@ -1,8 +1,6 @@
 ---
 title: AlignLayersMiddle
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the AlignLayersMiddle action will appear here.
+No details available for `AlignLayersMiddle`.

--- a/_actions/AlignLayersRight.md
+++ b/_actions/AlignLayersRight.md
@@ -1,8 +1,6 @@
 ---
 title: AlignLayersRight
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the AlignLayersRight action will appear here.
+No details available for `AlignLayersRight`.

--- a/_actions/AlignLayersTop.md
+++ b/_actions/AlignLayersTop.md
@@ -1,8 +1,6 @@
 ---
 title: AlignLayersTop
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the AlignLayersTop action will appear here.
+No details available for `AlignLayersTop`.

--- a/_actions/AlignLeft.md
+++ b/_actions/AlignLeft.md
@@ -1,8 +1,6 @@
 ---
 title: AlignLeft
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the AlignLeft action will appear here.
+No details available for `AlignLeft`.

--- a/_actions/AlignMiddle.md
+++ b/_actions/AlignMiddle.md
@@ -1,8 +1,6 @@
 ---
 title: AlignMiddle
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the AlignMiddle action will appear here.
+No details available for `AlignMiddle`.

--- a/_actions/AlignRight.md
+++ b/_actions/AlignRight.md
@@ -1,8 +1,6 @@
 ---
 title: AlignRight
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the AlignRight action will appear here.
+No details available for `AlignRight`.

--- a/_actions/AlignTop.md
+++ b/_actions/AlignTop.md
@@ -1,8 +1,6 @@
 ---
 title: AlignTop
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the AlignTop action will appear here.
+No details available for `AlignTop`.

--- a/_actions/AlignmentActions.md
+++ b/_actions/AlignmentActions.md
@@ -1,8 +1,6 @@
 ---
 title: AlignmentActions
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the AlignmentActions action will appear here.
+No details available for `AlignmentActions`.

--- a/_actions/ApplyData.md
+++ b/_actions/ApplyData.md
@@ -1,8 +1,6 @@
 ---
 title: ApplyData
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ApplyData action will appear here.
+No details available for `ApplyData`.

--- a/_actions/ApplyHorizontalFlip.md
+++ b/_actions/ApplyHorizontalFlip.md
@@ -1,8 +1,6 @@
 ---
 title: ApplyHorizontalFlip
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ApplyHorizontalFlip action will appear here.
+No details available for `ApplyHorizontalFlip`.

--- a/_actions/ApplyVerticalFlip.md
+++ b/_actions/ApplyVerticalFlip.md
@@ -1,8 +1,6 @@
 ---
 title: ApplyVerticalFlip
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ApplyVerticalFlip action will appear here.
+No details available for `ApplyVerticalFlip`.

--- a/_actions/AssignColorSpace.md
+++ b/_actions/AssignColorSpace.md
@@ -1,8 +1,6 @@
 ---
 title: AssignColorSpace
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the AssignColorSpace action will appear here.
+No details available for `AssignColorSpace`.

--- a/_actions/Assistant.md
+++ b/_actions/Assistant.md
@@ -1,8 +1,6 @@
 ---
 title: Assistant
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the Assistant action will appear here.
+No details available for `Assistant`.

--- a/_actions/AssistantActivate.md
+++ b/_actions/AssistantActivate.md
@@ -1,0 +1,6 @@
+---
+title: AssistantActivate
+summary:
+---
+
+No details available for `AssistantActivate`.

--- a/_actions/AssistantCheckDocument.md
+++ b/_actions/AssistantCheckDocument.md
@@ -1,8 +1,6 @@
 ---
 title: AssistantCheckDocument
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the AssistantCheckDocument action will appear here.
+No details available for `AssistantCheckDocument`.

--- a/_actions/AssistantCheckDocumentAutomatically.md
+++ b/_actions/AssistantCheckDocumentAutomatically.md
@@ -1,8 +1,6 @@
 ---
 title: AssistantCheckDocumentAutomatically
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the AssistantCheckDocumentAutomatically action will appear here.
+No details available for `AssistantCheckDocumentAutomatically`.

--- a/_actions/AssistantConfigure.md
+++ b/_actions/AssistantConfigure.md
@@ -1,0 +1,6 @@
+---
+title: AssistantConfigure
+summary:
+---
+
+No details available for `AssistantConfigure`.

--- a/_actions/AssistantInstallFromDisk.md
+++ b/_actions/AssistantInstallFromDisk.md
@@ -1,8 +1,6 @@
 ---
 title: AssistantInstallFromDisk
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the AssistantInstallFromDisk action will appear here.
+No details available for `AssistantInstallFromDisk`.

--- a/_actions/AssistantInstallFromURL.md
+++ b/_actions/AssistantInstallFromURL.md
@@ -1,8 +1,6 @@
 ---
 title: AssistantInstallFromURL
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the AssistantInstallFromURL action will appear here.
+No details available for `AssistantInstallFromURL`.

--- a/_actions/AssistantInstallMissing.md
+++ b/_actions/AssistantInstallMissing.md
@@ -1,0 +1,6 @@
+---
+title: AssistantInstallMissing
+summary:
+---
+
+No details available for `AssistantInstallMissing`.

--- a/_actions/AssistantRemove.md
+++ b/_actions/AssistantRemove.md
@@ -1,8 +1,0 @@
----
-title: AssistantRemove
-summary: work in progress
----
-
-Work In Progress
-
-Documentation for the AssistantRemove action will appear here.

--- a/_actions/AssistantShowIgnored.md
+++ b/_actions/AssistantShowIgnored.md
@@ -1,0 +1,6 @@
+---
+title: AssistantShowIgnored
+summary:
+---
+
+No details available for `AssistantShowIgnored`.

--- a/_actions/AutoExpandGroups.md
+++ b/_actions/AutoExpandGroups.md
@@ -1,8 +1,6 @@
 ---
 title: AutoExpandGroups
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the AutoExpandGroups action will appear here.
+No details available for `AutoExpandGroups`.

--- a/_actions/BackToInstance.md
+++ b/_actions/BackToInstance.md
@@ -1,8 +1,6 @@
 ---
 title: BackToInstance
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the BackToInstance action will appear here.
+No details available for `BackToInstance`.

--- a/_actions/BadgeMenu.md
+++ b/_actions/BadgeMenu.md
@@ -1,8 +1,6 @@
 ---
 title: BadgeMenu
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the BadgeMenu action will appear here.
+No details available for `BadgeMenu`.

--- a/_actions/BaseAlignLayers.md
+++ b/_actions/BaseAlignLayers.md
@@ -1,8 +1,6 @@
 ---
 title: BaseAlignLayers
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the BaseAlignLayers action will appear here.
+No details available for `BaseAlignLayers`.

--- a/_actions/BaseStyle.md
+++ b/_actions/BaseStyle.md
@@ -1,8 +1,6 @@
 ---
 title: BaseStyle
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the BaseStyle action will appear here.
+No details available for `BaseStyle`.

--- a/_actions/BooleanActionGroup.md
+++ b/_actions/BooleanActionGroup.md
@@ -1,8 +1,6 @@
 ---
 title: BooleanActionGroup
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the BooleanActionGroup action will appear here.
+No details available for `BooleanActionGroup`.

--- a/_actions/BooleanMenu.md
+++ b/_actions/BooleanMenu.md
@@ -1,8 +1,6 @@
 ---
 title: BooleanMenu
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the BooleanMenu action will appear here.
+No details available for `BooleanMenu`.

--- a/_actions/CenterLayersInCanvas.md
+++ b/_actions/CenterLayersInCanvas.md
@@ -1,8 +1,6 @@
 ---
 title: CenterLayersInCanvas
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the CenterLayersInCanvas action will appear here.
+No details available for `CenterLayersInCanvas`.

--- a/_actions/CenterSelectionInVisibleArea.md
+++ b/_actions/CenterSelectionInVisibleArea.md
@@ -1,8 +1,6 @@
 ---
 title: CenterSelectionInVisibleArea
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the CenterSelectionInVisibleArea action will appear here.
+No details available for `CenterSelectionInVisibleArea`.

--- a/_actions/ChangeFlowAnimationFromBottomAnimation.md
+++ b/_actions/ChangeFlowAnimationFromBottomAnimation.md
@@ -1,8 +1,6 @@
 ---
 title: ChangeFlowAnimationFromBottomAnimation
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ChangeFlowAnimationFromBottomAnimation action will appear here.
+No details available for `ChangeFlowAnimationFromBottomAnimation`.

--- a/_actions/ChangeFlowAnimationFromLeftAnimation.md
+++ b/_actions/ChangeFlowAnimationFromLeftAnimation.md
@@ -1,8 +1,6 @@
 ---
 title: ChangeFlowAnimationFromLeftAnimation
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ChangeFlowAnimationFromLeftAnimation action will appear here.
+No details available for `ChangeFlowAnimationFromLeftAnimation`.

--- a/_actions/ChangeFlowAnimationFromRightAnimation.md
+++ b/_actions/ChangeFlowAnimationFromRightAnimation.md
@@ -1,8 +1,6 @@
 ---
 title: ChangeFlowAnimationFromRightAnimation
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ChangeFlowAnimationFromRightAnimation action will appear here.
+No details available for `ChangeFlowAnimationFromRightAnimation`.

--- a/_actions/ChangeFlowAnimationFromTopAnimation.md
+++ b/_actions/ChangeFlowAnimationFromTopAnimation.md
@@ -1,8 +1,6 @@
 ---
 title: ChangeFlowAnimationFromTopAnimation
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ChangeFlowAnimationFromTopAnimation action will appear here.
+No details available for `ChangeFlowAnimationFromTopAnimation`.

--- a/_actions/ChangeFlowAnimationNoAnimation.md
+++ b/_actions/ChangeFlowAnimationNoAnimation.md
@@ -1,8 +1,6 @@
 ---
 title: ChangeFlowAnimationNoAnimation
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ChangeFlowAnimationNoAnimation action will appear here.
+No details available for `ChangeFlowAnimationNoAnimation`.

--- a/_actions/ChangeFont.md
+++ b/_actions/ChangeFont.md
@@ -1,8 +1,6 @@
 ---
 title: ChangeFont
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ChangeFont action will appear here.
+No details available for `ChangeFont`.

--- a/_actions/ChangeInferredLayout.md
+++ b/_actions/ChangeInferredLayout.md
@@ -1,8 +1,6 @@
 ---
 title: ChangeInferredLayout
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ChangeInferredLayout action will appear here.
+No details available for `ChangeInferredLayout`.

--- a/_actions/ClearDataRecord.md
+++ b/_actions/ClearDataRecord.md
@@ -1,8 +1,6 @@
 ---
 title: ClearDataRecord
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ClearDataRecord action will appear here.
+No details available for `ClearDataRecord`.

--- a/_actions/ClippingMask.md
+++ b/_actions/ClippingMask.md
@@ -1,8 +1,6 @@
 ---
 title: ClippingMask
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ClippingMask action will appear here.
+No details available for `ClippingMask`.

--- a/_actions/ClippingMaskMode.md
+++ b/_actions/ClippingMaskMode.md
@@ -1,8 +1,6 @@
 ---
 title: ClippingMaskMode
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ClippingMaskMode action will appear here.
+No details available for `ClippingMaskMode`.

--- a/_actions/ClosePath.md
+++ b/_actions/ClosePath.md
@@ -1,8 +1,6 @@
 ---
 title: ClosePath
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ClosePath action will appear here.
+No details available for `ClosePath`.

--- a/_actions/Cloud.md
+++ b/_actions/Cloud.md
@@ -1,8 +1,6 @@
 ---
 title: Cloud
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the Cloud action will appear here.
+No details available for `Cloud`.

--- a/_actions/CollapseAllGroups.md
+++ b/_actions/CollapseAllGroups.md
@@ -1,8 +1,6 @@
 ---
 title: CollapseAllGroups
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the CollapseAllGroups action will appear here.
+No details available for `CollapseAllGroups`.

--- a/_actions/ColorInspectorCircularGradientTab.md
+++ b/_actions/ColorInspectorCircularGradientTab.md
@@ -1,8 +1,6 @@
 ---
 title: ColorInspectorCircularGradientTab
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ColorInspectorCircularGradientTab action will appear here.
+No details available for `ColorInspectorCircularGradientTab`.

--- a/_actions/ColorInspectorColorTab.md
+++ b/_actions/ColorInspectorColorTab.md
@@ -1,8 +1,6 @@
 ---
 title: ColorInspectorColorTab
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ColorInspectorColorTab action will appear here.
+No details available for `ColorInspectorColorTab`.

--- a/_actions/ColorInspectorImageTab.md
+++ b/_actions/ColorInspectorImageTab.md
@@ -1,8 +1,6 @@
 ---
 title: ColorInspectorImageTab
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ColorInspectorImageTab action will appear here.
+No details available for `ColorInspectorImageTab`.

--- a/_actions/ColorInspectorLinearGradientTab.md
+++ b/_actions/ColorInspectorLinearGradientTab.md
@@ -1,8 +1,6 @@
 ---
 title: ColorInspectorLinearGradientTab
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ColorInspectorLinearGradientTab action will appear here.
+No details available for `ColorInspectorLinearGradientTab`.

--- a/_actions/ColorInspectorModeBorderTouchBarGroup.md
+++ b/_actions/ColorInspectorModeBorderTouchBarGroup.md
@@ -1,8 +1,6 @@
 ---
 title: ColorInspectorModeBorderTouchBarGroup
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ColorInspectorModeBorderTouchBarGroup action will appear here.
+No details available for `ColorInspectorModeBorderTouchBarGroup`.

--- a/_actions/ColorInspectorModeFillTouchBarGroup.md
+++ b/_actions/ColorInspectorModeFillTouchBarGroup.md
@@ -1,8 +1,6 @@
 ---
 title: ColorInspectorModeFillTouchBarGroup
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ColorInspectorModeFillTouchBarGroup action will appear here.
+No details available for `ColorInspectorModeFillTouchBarGroup`.

--- a/_actions/ColorInspectorModePicker.md
+++ b/_actions/ColorInspectorModePicker.md
@@ -1,8 +1,6 @@
 ---
 title: ColorInspectorModePicker
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ColorInspectorModePicker action will appear here.
+No details available for `ColorInspectorModePicker`.

--- a/_actions/ColorInspectorRadialGradientTab.md
+++ b/_actions/ColorInspectorRadialGradientTab.md
@@ -1,8 +1,6 @@
 ---
 title: ColorInspectorRadialGradientTab
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ColorInspectorRadialGradientTab action will appear here.
+No details available for `ColorInspectorRadialGradientTab`.

--- a/_actions/ConstraintFixHeight.md
+++ b/_actions/ConstraintFixHeight.md
@@ -1,8 +1,6 @@
 ---
 title: ConstraintFixHeight
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ConstraintFixHeight action will appear here.
+No details available for `ConstraintFixHeight`.

--- a/_actions/ConstraintFixWidth.md
+++ b/_actions/ConstraintFixWidth.md
@@ -1,8 +1,6 @@
 ---
 title: ConstraintFixWidth
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ConstraintFixWidth action will appear here.
+No details available for `ConstraintFixWidth`.

--- a/_actions/ConstraintPinBottom.md
+++ b/_actions/ConstraintPinBottom.md
@@ -1,8 +1,6 @@
 ---
 title: ConstraintPinBottom
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ConstraintPinBottom action will appear here.
+No details available for `ConstraintPinBottom`.

--- a/_actions/ConstraintPinLeft.md
+++ b/_actions/ConstraintPinLeft.md
@@ -1,8 +1,6 @@
 ---
 title: ConstraintPinLeft
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ConstraintPinLeft action will appear here.
+No details available for `ConstraintPinLeft`.

--- a/_actions/ConstraintPinRight.md
+++ b/_actions/ConstraintPinRight.md
@@ -1,8 +1,6 @@
 ---
 title: ConstraintPinRight
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ConstraintPinRight action will appear here.
+No details available for `ConstraintPinRight`.

--- a/_actions/ConstraintPinTop.md
+++ b/_actions/ConstraintPinTop.md
@@ -1,8 +1,6 @@
 ---
 title: ConstraintPinTop
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ConstraintPinTop action will appear here.
+No details available for `ConstraintPinTop`.

--- a/_actions/ConstraintReset.md
+++ b/_actions/ConstraintReset.md
@@ -1,8 +1,6 @@
 ---
 title: ConstraintReset
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ConstraintReset action will appear here.
+No details available for `ConstraintReset`.

--- a/_actions/ContextMenuData.md
+++ b/_actions/ContextMenuData.md
@@ -1,8 +1,6 @@
 ---
 title: ContextMenuData
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ContextMenuData action will appear here.
+No details available for `ContextMenuData`.

--- a/_actions/ConvertColorSpace.md
+++ b/_actions/ConvertColorSpace.md
@@ -1,8 +1,6 @@
 ---
 title: ConvertColorSpace
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ConvertColorSpace action will appear here.
+No details available for `ConvertColorSpace`.

--- a/_actions/ConvertFlowToHotspot.md
+++ b/_actions/ConvertFlowToHotspot.md
@@ -1,8 +1,6 @@
 ---
 title: ConvertFlowToHotspot
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ConvertFlowToHotspot action will appear here.
+No details available for `ConvertFlowToHotspot`.

--- a/_actions/ConvertSymbolOrDetachInstances.md
+++ b/_actions/ConvertSymbolOrDetachInstances.md
@@ -1,8 +1,6 @@
 ---
 title: ConvertSymbolOrDetachInstances
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ConvertSymbolOrDetachInstances action will appear here.
+No details available for `ConvertSymbolOrDetachInstances`.

--- a/_actions/ConvertSymbolOrDetachInstancesRecursively.md
+++ b/_actions/ConvertSymbolOrDetachInstancesRecursively.md
@@ -1,8 +1,6 @@
 ---
 title: ConvertSymbolOrDetachInstancesRecursively
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ConvertSymbolOrDetachInstancesRecursively action will appear here.
+No details available for `ConvertSymbolOrDetachInstancesRecursively`.

--- a/_actions/ConvertToOutlines.md
+++ b/_actions/ConvertToOutlines.md
@@ -1,8 +1,6 @@
 ---
 title: ConvertToOutlines
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ConvertToOutlines action will appear here.
+No details available for `ConvertToOutlines`.

--- a/_actions/Copy.md
+++ b/_actions/Copy.md
@@ -1,8 +1,6 @@
 ---
 title: Copy
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the Copy action will appear here.
+No details available for `Copy`.

--- a/_actions/CopyCSSAttributes.md
+++ b/_actions/CopyCSSAttributes.md
@@ -1,8 +1,6 @@
 ---
 title: CopyCSSAttributes
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the CopyCSSAttributes action will appear here.
+No details available for `CopyCSSAttributes`.

--- a/_actions/CopyCloudDocumentLink.md
+++ b/_actions/CopyCloudDocumentLink.md
@@ -1,8 +1,6 @@
 ---
 title: CopyCloudDocumentLink
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the CopyCloudDocumentLink action will appear here.
+No details available for `CopyCloudDocumentLink`.

--- a/_actions/CopyOverride.md
+++ b/_actions/CopyOverride.md
@@ -1,8 +1,6 @@
 ---
 title: CopyOverride
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the CopyOverride action will appear here.
+No details available for `CopyOverride`.

--- a/_actions/CopySVGCode.md
+++ b/_actions/CopySVGCode.md
@@ -1,8 +1,6 @@
 ---
 title: CopySVGCode
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the CopySVGCode action will appear here.
+No details available for `CopySVGCode`.

--- a/_actions/CopyStyle.md
+++ b/_actions/CopyStyle.md
@@ -1,8 +1,6 @@
 ---
 title: CopyStyle
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the CopyStyle action will appear here.
+No details available for `CopyStyle`.

--- a/_actions/CreateSharedColor.md
+++ b/_actions/CreateSharedColor.md
@@ -1,0 +1,6 @@
+---
+title: CreateSharedColor
+summary:
+---
+
+No details available for `CreateSharedColor`.

--- a/_actions/CreateSharedStyle.md
+++ b/_actions/CreateSharedStyle.md
@@ -1,8 +1,6 @@
 ---
 title: CreateSharedStyle
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the CreateSharedStyle action will appear here.
+No details available for `CreateSharedStyle`.

--- a/_actions/CreateSymbol.md
+++ b/_actions/CreateSymbol.md
@@ -1,8 +1,6 @@
 ---
 title: CreateSymbol
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the CreateSymbol action will appear here.
+No details available for `CreateSymbol`.

--- a/_actions/CurveModeAsymmetric.md
+++ b/_actions/CurveModeAsymmetric.md
@@ -1,8 +1,6 @@
 ---
 title: CurveModeAsymmetric
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the CurveModeAsymmetric action will appear here.
+No details available for `CurveModeAsymmetric`.

--- a/_actions/CurveModeDisconnected.md
+++ b/_actions/CurveModeDisconnected.md
@@ -1,8 +1,6 @@
 ---
 title: CurveModeDisconnected
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the CurveModeDisconnected action will appear here.
+No details available for `CurveModeDisconnected`.

--- a/_actions/CurveModeMirrored.md
+++ b/_actions/CurveModeMirrored.md
@@ -1,8 +1,6 @@
 ---
 title: CurveModeMirrored
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the CurveModeMirrored action will appear here.
+No details available for `CurveModeMirrored`.

--- a/_actions/CurveModeStraight.md
+++ b/_actions/CurveModeStraight.md
@@ -1,8 +1,6 @@
 ---
 title: CurveModeStraight
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the CurveModeStraight action will appear here.
+No details available for `CurveModeStraight`.

--- a/_actions/CurveModeTouchGroup.md
+++ b/_actions/CurveModeTouchGroup.md
@@ -1,8 +1,6 @@
 ---
 title: CurveModeTouchGroup
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the CurveModeTouchGroup action will appear here.
+No details available for `CurveModeTouchGroup`.

--- a/_actions/Cut.md
+++ b/_actions/Cut.md
@@ -1,8 +1,6 @@
 ---
 title: Cut
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the Cut action will appear here.
+No details available for `Cut`.

--- a/_actions/Data.md
+++ b/_actions/Data.md
@@ -1,8 +1,0 @@
----
-title: Data
-summary: work in progress
----
-
-Work In Progress
-
-Documentation for the Data action will appear here.

--- a/_actions/DataMenu.md
+++ b/_actions/DataMenu.md
@@ -1,8 +1,6 @@
 ---
 title: DataMenu
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the DataMenu action will appear here.
+No details available for `DataMenu`.

--- a/_actions/DefaultStyle.md
+++ b/_actions/DefaultStyle.md
@@ -1,8 +1,6 @@
 ---
 title: DefaultStyle
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the DefaultStyle action will appear here.
+No details available for `DefaultStyle`.

--- a/_actions/Delete.md
+++ b/_actions/Delete.md
@@ -1,8 +1,6 @@
 ---
 title: Delete
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the Delete action will appear here.
+No details available for `Delete`.

--- a/_actions/DetachSharedColor.md
+++ b/_actions/DetachSharedColor.md
@@ -1,0 +1,6 @@
+---
+title: DetachSharedColor
+summary:
+---
+
+No details available for `DetachSharedColor`.

--- a/_actions/DetachSharedStyle.md
+++ b/_actions/DetachSharedStyle.md
@@ -1,8 +1,6 @@
 ---
 title: DetachSharedStyle
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the DetachSharedStyle action will appear here.
+No details available for `DetachSharedStyle`.

--- a/_actions/DetachSybolInstances.md
+++ b/_actions/DetachSybolInstances.md
@@ -1,8 +1,0 @@
----
-title: DetachSybolInstances
-summary: work in progress
----
-
-Work In Progress
-
-Documentation for the DetachSybolInstances action will appear here.

--- a/_actions/Difference.md
+++ b/_actions/Difference.md
@@ -1,8 +1,6 @@
 ---
 title: Difference
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the Difference action will appear here.
+No details available for `Difference`.

--- a/_actions/DistributeActions.md
+++ b/_actions/DistributeActions.md
@@ -1,8 +1,6 @@
 ---
 title: DistributeActions
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the DistributeActions action will appear here.
+No details available for `DistributeActions`.

--- a/_actions/DistributeHorizontally.md
+++ b/_actions/DistributeHorizontally.md
@@ -1,8 +1,6 @@
 ---
 title: DistributeHorizontally
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the DistributeHorizontally action will appear here.
+No details available for `DistributeHorizontally`.

--- a/_actions/DistributeVertically.md
+++ b/_actions/DistributeVertically.md
@@ -1,8 +1,6 @@
 ---
 title: DistributeVertically
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the DistributeVertically action will appear here.
+No details available for `DistributeVertically`.

--- a/_actions/Duplicate.md
+++ b/_actions/Duplicate.md
@@ -1,8 +1,6 @@
 ---
 title: Duplicate
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the Duplicate action will appear here.
+No details available for `Duplicate`.

--- a/_actions/Edit.md
+++ b/_actions/Edit.md
@@ -1,8 +1,6 @@
 ---
 title: Edit
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the Edit action will appear here.
+No details available for `Edit`.

--- a/_actions/EditColorSpace.md
+++ b/_actions/EditColorSpace.md
@@ -1,8 +1,6 @@
 ---
 title: EditColorSpace
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the EditColorSpace action will appear here.
+No details available for `EditColorSpace`.

--- a/_actions/Export.md
+++ b/_actions/Export.md
@@ -1,8 +1,6 @@
 ---
 title: Export
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the Export action will appear here.
+No details available for `Export`.

--- a/_actions/ExportPDFBook.md
+++ b/_actions/ExportPDFBook.md
@@ -1,8 +1,6 @@
 ---
 title: ExportPDFBook
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ExportPDFBook action will appear here.
+No details available for `ExportPDFBook`.

--- a/_actions/ExportSelectionWithExportFormats.md
+++ b/_actions/ExportSelectionWithExportFormats.md
@@ -1,8 +1,6 @@
 ---
 title: ExportSelectionWithExportFormats
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ExportSelectionWithExportFormats action will appear here.
+No details available for `ExportSelectionWithExportFormats`.

--- a/_actions/Find.md
+++ b/_actions/Find.md
@@ -1,0 +1,6 @@
+---
+title: Find
+summary:
+---
+
+No details available for `Find`.

--- a/_actions/FindLayer.md
+++ b/_actions/FindLayer.md
@@ -1,8 +1,0 @@
----
-title: FindLayer
-summary: work in progress
----
-
-Work In Progress
-
-Documentation for the FindLayer action will appear here.

--- a/_actions/Flatten.md
+++ b/_actions/Flatten.md
@@ -1,8 +1,6 @@
 ---
 title: Flatten
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the Flatten action will appear here.
+No details available for `Flatten`.

--- a/_actions/FlattenSelection.md
+++ b/_actions/FlattenSelection.md
@@ -1,8 +1,6 @@
 ---
 title: FlattenSelection
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the FlattenSelection action will appear here.
+No details available for `FlattenSelection`.

--- a/_actions/FlipHorizontal.md
+++ b/_actions/FlipHorizontal.md
@@ -1,8 +1,6 @@
 ---
 title: FlipHorizontal
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the FlipHorizontal action will appear here.
+No details available for `FlipHorizontal`.

--- a/_actions/FlipVertical.md
+++ b/_actions/FlipVertical.md
@@ -1,8 +1,6 @@
 ---
 title: FlipVertical
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the FlipVertical action will appear here.
+No details available for `FlipVertical`.

--- a/_actions/FollowFlow.md
+++ b/_actions/FollowFlow.md
@@ -1,8 +1,6 @@
 ---
 title: FollowFlow
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the FollowFlow action will appear here.
+No details available for `FollowFlow`.

--- a/_actions/ForceResyncLibrary.md
+++ b/_actions/ForceResyncLibrary.md
@@ -1,8 +1,6 @@
 ---
 title: ForceResyncLibrary
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ForceResyncLibrary action will appear here.
+No details available for `ForceResyncLibrary`.

--- a/_actions/GridSettings.md
+++ b/_actions/GridSettings.md
@@ -1,8 +1,6 @@
 ---
 title: GridSettings
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the GridSettings action will appear here.
+No details available for `GridSettings`.

--- a/_actions/Group.md
+++ b/_actions/Group.md
@@ -1,8 +1,6 @@
 ---
 title: Group
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the Group action will appear here.
+No details available for `Group`.

--- a/_actions/GroupActionGroup.md
+++ b/_actions/GroupActionGroup.md
@@ -1,8 +1,6 @@
 ---
 title: GroupActionGroup
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the GroupActionGroup action will appear here.
+No details available for `GroupActionGroup`.

--- a/_actions/HandlerGotFocus.md
+++ b/_actions/HandlerGotFocus.md
@@ -1,8 +1,6 @@
 ---
 title: HandlerGotFocus
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the HandlerGotFocus action will appear here.
+No details available for `HandlerGotFocus`.

--- a/_actions/HandlerLostFocus.md
+++ b/_actions/HandlerLostFocus.md
@@ -1,8 +1,6 @@
 ---
 title: HandlerLostFocus
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the HandlerLostFocus action will appear here.
+No details available for `HandlerLostFocus`.

--- a/_actions/HideAllGridsAndLayouts.md
+++ b/_actions/HideAllGridsAndLayouts.md
@@ -1,8 +1,6 @@
 ---
 title: HideAllGridsAndLayouts
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the HideAllGridsAndLayouts action will appear here.
+No details available for `HideAllGridsAndLayouts`.

--- a/_actions/HideLayer.md
+++ b/_actions/HideLayer.md
@@ -1,8 +1,6 @@
 ---
 title: HideLayer
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the HideLayer action will appear here.
+No details available for `HideLayer`.

--- a/_actions/IgnoreClippingMask.md
+++ b/_actions/IgnoreClippingMask.md
@@ -1,8 +1,6 @@
 ---
 title: IgnoreClippingMask
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the IgnoreClippingMask action will appear here.
+No details available for `IgnoreClippingMask`.

--- a/_actions/ImageOriginalSize.md
+++ b/_actions/ImageOriginalSize.md
@@ -1,8 +1,6 @@
 ---
 title: ImageOriginalSize
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ImageOriginalSize action will appear here.
+No details available for `ImageOriginalSize`.

--- a/_actions/IncompatiblePluginsDisabled.md
+++ b/_actions/IncompatiblePluginsDisabled.md
@@ -1,8 +1,6 @@
 ---
 title: IncompatiblePluginsDisabled
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the IncompatiblePluginsDisabled action will appear here.
+No details available for `IncompatiblePluginsDisabled`.

--- a/_actions/InsertArrow.md
+++ b/_actions/InsertArrow.md
@@ -1,8 +1,6 @@
 ---
 title: InsertArrow
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the InsertArrow action will appear here.
+No details available for `InsertArrow`.

--- a/_actions/InsertArtboard.md
+++ b/_actions/InsertArtboard.md
@@ -1,8 +1,6 @@
 ---
 title: InsertArtboard
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the InsertArtboard action will appear here.
+No details available for `InsertArtboard`.

--- a/_actions/InsertHotspot.md
+++ b/_actions/InsertHotspot.md
@@ -1,8 +1,6 @@
 ---
 title: InsertHotspot
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the InsertHotspot action will appear here.
+No details available for `InsertHotspot`.

--- a/_actions/InsertImage.md
+++ b/_actions/InsertImage.md
@@ -1,8 +1,6 @@
 ---
 title: InsertImage
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the InsertImage action will appear here.
+No details available for `InsertImage`.

--- a/_actions/InsertLine.md
+++ b/_actions/InsertLine.md
@@ -1,8 +1,6 @@
 ---
 title: InsertLine
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the InsertLine action will appear here.
+No details available for `InsertLine`.

--- a/_actions/InsertMenu.md
+++ b/_actions/InsertMenu.md
@@ -1,8 +1,6 @@
 ---
 title: InsertMenu
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the InsertMenu action will appear here.
+No details available for `InsertMenu`.

--- a/_actions/InsertSharedText.md
+++ b/_actions/InsertSharedText.md
@@ -1,8 +1,6 @@
 ---
 title: InsertSharedText
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the InsertSharedText action will appear here.
+No details available for `InsertSharedText`.

--- a/_actions/InsertSlice.md
+++ b/_actions/InsertSlice.md
@@ -1,8 +1,6 @@
 ---
 title: InsertSlice
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the InsertSlice action will appear here.
+No details available for `InsertSlice`.

--- a/_actions/InsertSymbol.md
+++ b/_actions/InsertSymbol.md
@@ -1,8 +1,6 @@
 ---
 title: InsertSymbol
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the InsertSymbol action will appear here.
+No details available for `InsertSymbol`.

--- a/_actions/InsertTextLayer.md
+++ b/_actions/InsertTextLayer.md
@@ -1,8 +1,6 @@
 ---
 title: InsertTextLayer
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the InsertTextLayer action will appear here.
+No details available for `InsertTextLayer`.

--- a/_actions/InsertVector.md
+++ b/_actions/InsertVector.md
@@ -1,8 +1,6 @@
 ---
 title: InsertVector
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the InsertVector action will appear here.
+No details available for `InsertVector`.

--- a/_actions/Intersect.md
+++ b/_actions/Intersect.md
@@ -1,8 +1,6 @@
 ---
 title: Intersect
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the Intersect action will appear here.
+No details available for `Intersect`.

--- a/_actions/Join.md
+++ b/_actions/Join.md
@@ -1,8 +1,6 @@
 ---
 title: Join
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the Join action will appear here.
+No details available for `Join`.

--- a/_actions/LayerFocusActions.md
+++ b/_actions/LayerFocusActions.md
@@ -1,8 +1,6 @@
 ---
 title: LayerFocusActions
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the LayerFocusActions action will appear here.
+No details available for `LayerFocusActions`.

--- a/_actions/LayerHeightFocus.md
+++ b/_actions/LayerHeightFocus.md
@@ -1,8 +1,6 @@
 ---
 title: LayerHeightFocus
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the LayerHeightFocus action will appear here.
+No details available for `LayerHeightFocus`.

--- a/_actions/LayerWidthFocus.md
+++ b/_actions/LayerWidthFocus.md
@@ -1,8 +1,6 @@
 ---
 title: LayerWidthFocus
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the LayerWidthFocus action will appear here.
+No details available for `LayerWidthFocus`.

--- a/_actions/LayerXFocus.md
+++ b/_actions/LayerXFocus.md
@@ -1,8 +1,6 @@
 ---
 title: LayerXFocus
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the LayerXFocus action will appear here.
+No details available for `LayerXFocus`.

--- a/_actions/LayerYFocus.md
+++ b/_actions/LayerYFocus.md
@@ -1,8 +1,6 @@
 ---
 title: LayerYFocus
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the LayerYFocus action will appear here.
+No details available for `LayerYFocus`.

--- a/_actions/LayoutSettings.md
+++ b/_actions/LayoutSettings.md
@@ -1,8 +1,6 @@
 ---
 title: LayoutSettings
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the LayoutSettings action will appear here.
+No details available for `LayoutSettings`.

--- a/_actions/LegacyInsertMenu.md
+++ b/_actions/LegacyInsertMenu.md
@@ -1,0 +1,6 @@
+---
+title: LegacyInsertMenu
+summary:
+---
+
+No details available for `LegacyInsertMenu`.

--- a/_actions/LicenseExpired.md
+++ b/_actions/LicenseExpired.md
@@ -1,8 +1,6 @@
 ---
 title: LicenseExpired
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the LicenseExpired action will appear here.
+No details available for `LicenseExpired`.

--- a/_actions/ListTypeActionBullet.md
+++ b/_actions/ListTypeActionBullet.md
@@ -1,8 +1,6 @@
 ---
 title: ListTypeActionBullet
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ListTypeActionBullet action will appear here.
+No details available for `ListTypeActionBullet`.

--- a/_actions/ListTypeActionNone.md
+++ b/_actions/ListTypeActionNone.md
@@ -1,8 +1,6 @@
 ---
 title: ListTypeActionNone
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ListTypeActionNone action will appear here.
+No details available for `ListTypeActionNone`.

--- a/_actions/ListTypeActionNumbered.md
+++ b/_actions/ListTypeActionNumbered.md
@@ -1,8 +1,6 @@
 ---
 title: ListTypeActionNumbered
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ListTypeActionNumbered action will appear here.
+No details available for `ListTypeActionNumbered`.

--- a/_actions/LockLayer.md
+++ b/_actions/LockLayer.md
@@ -1,8 +1,6 @@
 ---
 title: LockLayer
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the LockLayer action will appear here.
+No details available for `LockLayer`.

--- a/_actions/Magnifier.md
+++ b/_actions/Magnifier.md
@@ -1,8 +1,6 @@
 ---
 title: Magnifier
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the Magnifier action will appear here.
+No details available for `Magnifier`.

--- a/_actions/MainMenuData.md
+++ b/_actions/MainMenuData.md
@@ -1,8 +1,6 @@
 ---
 title: MainMenuData
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the MainMenuData action will appear here.
+No details available for `MainMenuData`.

--- a/_actions/MakeGrid.md
+++ b/_actions/MakeGrid.md
@@ -1,8 +1,6 @@
 ---
 title: MakeGrid
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the MakeGrid action will appear here.
+No details available for `MakeGrid`.

--- a/_actions/MakeLowercase.md
+++ b/_actions/MakeLowercase.md
@@ -1,8 +1,6 @@
 ---
 title: MakeLowercase
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the MakeLowercase action will appear here.
+No details available for `MakeLowercase`.

--- a/_actions/MakeUppercase.md
+++ b/_actions/MakeUppercase.md
@@ -1,8 +1,6 @@
 ---
 title: MakeUppercase
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the MakeUppercase action will appear here.
+No details available for `MakeUppercase`.

--- a/_actions/ManageCloudDocumentShareSettings.md
+++ b/_actions/ManageCloudDocumentShareSettings.md
@@ -1,8 +1,6 @@
 ---
 title: ManageCloudDocumentShareSettings
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ManageCloudDocumentShareSettings action will appear here.
+No details available for `ManageCloudDocumentShareSettings`.

--- a/_actions/ManageComponents.md
+++ b/_actions/ManageComponents.md
@@ -1,8 +1,0 @@
----
-title: ManageComponents
-summary: work in progress
----
-
-Work In Progress
-
-Documentation for the ManageComponents action will appear here.

--- a/_actions/ManageShareableObjects.md
+++ b/_actions/ManageShareableObjects.md
@@ -1,8 +1,0 @@
----
-title: ManageShareableObjects
-summary: work in progress
----
-
-Work In Progress
-
-Documentation for the ManageShareableObjects action will appear here.

--- a/_actions/MaskWithShape.md
+++ b/_actions/MaskWithShape.md
@@ -1,8 +1,6 @@
 ---
 title: MaskWithShape
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the MaskWithShape action will appear here.
+No details available for `MaskWithShape`.

--- a/_actions/Mirror.md
+++ b/_actions/Mirror.md
@@ -1,8 +1,6 @@
 ---
 title: Mirror
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the Mirror action will appear here.
+No details available for `Mirror`.

--- a/_actions/MoveActionGroup.md
+++ b/_actions/MoveActionGroup.md
@@ -1,8 +1,6 @@
 ---
 title: MoveActionGroup
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the MoveActionGroup action will appear here.
+No details available for `MoveActionGroup`.

--- a/_actions/MoveBackward.md
+++ b/_actions/MoveBackward.md
@@ -1,8 +1,6 @@
 ---
 title: MoveBackward
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the MoveBackward action will appear here.
+No details available for `MoveBackward`.

--- a/_actions/MoveForward.md
+++ b/_actions/MoveForward.md
@@ -1,8 +1,6 @@
 ---
 title: MoveForward
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the MoveForward action will appear here.
+No details available for `MoveForward`.

--- a/_actions/MoveToBack.md
+++ b/_actions/MoveToBack.md
@@ -1,8 +1,6 @@
 ---
 title: MoveToBack
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the MoveToBack action will appear here.
+No details available for `MoveToBack`.

--- a/_actions/MoveToFront.md
+++ b/_actions/MoveToFront.md
@@ -1,8 +1,6 @@
 ---
 title: MoveToFront
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the MoveToFront action will appear here.
+No details available for `MoveToFront`.

--- a/_actions/MoveToTop.md
+++ b/_actions/MoveToTop.md
@@ -1,8 +1,6 @@
 ---
 title: MoveToTop
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the MoveToTop action will appear here.
+No details available for `MoveToTop`.

--- a/_actions/MoveUpHierarchy.md
+++ b/_actions/MoveUpHierarchy.md
@@ -1,8 +1,6 @@
 ---
 title: MoveUpHierarchy
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the MoveUpHierarchy action will appear here.
+No details available for `MoveUpHierarchy`.

--- a/_actions/NavigateToOverrideMaster.md
+++ b/_actions/NavigateToOverrideMaster.md
@@ -1,8 +1,6 @@
 ---
 title: NavigateToOverrideMaster
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the NavigateToOverrideMaster action will appear here.
+No details available for `NavigateToOverrideMaster`.

--- a/_actions/NewPage.md
+++ b/_actions/NewPage.md
@@ -1,8 +1,6 @@
 ---
 title: NewPage
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the NewPage action will appear here.
+No details available for `NewPage`.

--- a/_actions/NextPage.md
+++ b/_actions/NextPage.md
@@ -1,8 +1,6 @@
 ---
 title: NextPage
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the NextPage action will appear here.
+No details available for `NextPage`.

--- a/_actions/NineSlice.md
+++ b/_actions/NineSlice.md
@@ -1,8 +1,0 @@
----
-title: NineSlice
-summary: work in progress
----
-
-Work In Progress
-
-Documentation for the NineSlice action will appear here.

--- a/_actions/OffsetPath.md
+++ b/_actions/OffsetPath.md
@@ -1,8 +1,6 @@
 ---
 title: OffsetPath
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the OffsetPath action will appear here.
+No details available for `OffsetPath`.

--- a/_actions/OpenPreview.md
+++ b/_actions/OpenPreview.md
@@ -1,8 +1,6 @@
 ---
 title: OpenPreview
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the OpenPreview action will appear here.
+No details available for `OpenPreview`.

--- a/_actions/OpenStyleInLibrary.md
+++ b/_actions/OpenStyleInLibrary.md
@@ -1,8 +1,6 @@
 ---
 title: OpenStyleInLibrary
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the OpenStyleInLibrary action will appear here.
+No details available for `OpenStyleInLibrary`.

--- a/_actions/OpenSwatchInLibrary.md
+++ b/_actions/OpenSwatchInLibrary.md
@@ -1,0 +1,6 @@
+---
+title: OpenSwatchInLibrary
+summary:
+---
+
+No details available for `OpenSwatchInLibrary`.

--- a/_actions/OpenSymbolInLibrary.md
+++ b/_actions/OpenSymbolInLibrary.md
@@ -1,8 +1,6 @@
 ---
 title: OpenSymbolInLibrary
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the OpenSymbolInLibrary action will appear here.
+No details available for `OpenSymbolInLibrary`.

--- a/_actions/OpenTypeFeatures.md
+++ b/_actions/OpenTypeFeatures.md
@@ -1,8 +1,6 @@
 ---
 title: OpenTypeFeatures
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the OpenTypeFeatures action will appear here.
+No details available for `OpenTypeFeatures`.

--- a/_actions/OrganizeImportedSymbols.md
+++ b/_actions/OrganizeImportedSymbols.md
@@ -1,8 +1,6 @@
 ---
 title: OrganizeImportedSymbols
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the OrganizeImportedSymbols action will appear here.
+No details available for `OrganizeImportedSymbols`.

--- a/_actions/OvalShape.md
+++ b/_actions/OvalShape.md
@@ -1,8 +1,6 @@
 ---
 title: OvalShape
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the OvalShape action will appear here.
+No details available for `OvalShape`.

--- a/_actions/Paste.md
+++ b/_actions/Paste.md
@@ -1,8 +1,6 @@
 ---
 title: Paste
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the Paste action will appear here.
+No details available for `Paste`.

--- a/_actions/PasteHere.md
+++ b/_actions/PasteHere.md
@@ -1,8 +1,6 @@
 ---
 title: PasteHere
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the PasteHere action will appear here.
+No details available for `PasteHere`.

--- a/_actions/PasteOverSelection.md
+++ b/_actions/PasteOverSelection.md
@@ -1,8 +1,6 @@
 ---
 title: PasteOverSelection
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the PasteOverSelection action will appear here.
+No details available for `PasteOverSelection`.

--- a/_actions/PasteStyle.md
+++ b/_actions/PasteStyle.md
@@ -1,8 +1,6 @@
 ---
 title: PasteStyle
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the PasteStyle action will appear here.
+No details available for `PasteStyle`.

--- a/_actions/PasteWithStyle.md
+++ b/_actions/PasteWithStyle.md
@@ -1,8 +1,6 @@
 ---
 title: PasteWithStyle
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the PasteWithStyle action will appear here.
+No details available for `PasteWithStyle`.

--- a/_actions/Pencil.md
+++ b/_actions/Pencil.md
@@ -1,8 +1,6 @@
 ---
 title: Pencil
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the Pencil action will appear here.
+No details available for `Pencil`.

--- a/_actions/PolygonShape.md
+++ b/_actions/PolygonShape.md
@@ -1,8 +1,6 @@
 ---
 title: PolygonShape
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the PolygonShape action will appear here.
+No details available for `PolygonShape`.

--- a/_actions/PreviewAtActualSize.md
+++ b/_actions/PreviewAtActualSize.md
@@ -1,8 +1,6 @@
 ---
 title: PreviewAtActualSize
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the PreviewAtActualSize action will appear here.
+No details available for `PreviewAtActualSize`.

--- a/_actions/PreviousPage.md
+++ b/_actions/PreviousPage.md
@@ -1,8 +1,6 @@
 ---
 title: PreviousPage
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the PreviousPage action will appear here.
+No details available for `PreviousPage`.

--- a/_actions/Print.md
+++ b/_actions/Print.md
@@ -1,8 +1,6 @@
 ---
 title: Print
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the Print action will appear here.
+No details available for `Print`.

--- a/_actions/Publish.md
+++ b/_actions/Publish.md
@@ -1,8 +1,0 @@
----
-title: Publish
-summary: work in progress
----
-
-Work In Progress
-
-Documentation for the Publish action will appear here.

--- a/_actions/RectangleShape.md
+++ b/_actions/RectangleShape.md
@@ -1,8 +1,6 @@
 ---
 title: RectangleShape
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the RectangleShape action will appear here.
+No details available for `RectangleShape`.

--- a/_actions/Redo.md
+++ b/_actions/Redo.md
@@ -1,8 +1,6 @@
 ---
 title: Redo
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the Redo action will appear here.
+No details available for `Redo`.

--- a/_actions/ReduceFileSize.md
+++ b/_actions/ReduceFileSize.md
@@ -1,8 +1,6 @@
 ---
 title: ReduceFileSize
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ReduceFileSize action will appear here.
+No details available for `ReduceFileSize`.

--- a/_actions/ReduceImageSize.md
+++ b/_actions/ReduceImageSize.md
@@ -1,8 +1,6 @@
 ---
 title: ReduceImageSize
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ReduceImageSize action will appear here.
+No details available for `ReduceImageSize`.

--- a/_actions/RefreshData.md
+++ b/_actions/RefreshData.md
@@ -1,8 +1,6 @@
 ---
 title: RefreshData
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the RefreshData action will appear here.
+No details available for `RefreshData`.

--- a/_actions/RemoveAllOverrides.md
+++ b/_actions/RemoveAllOverrides.md
@@ -1,8 +1,6 @@
 ---
 title: RemoveAllOverrides
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the RemoveAllOverrides action will appear here.
+No details available for `RemoveAllOverrides`.

--- a/_actions/RemoveFlow.md
+++ b/_actions/RemoveFlow.md
@@ -1,8 +1,6 @@
 ---
 title: RemoveFlow
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the RemoveFlow action will appear here.
+No details available for `RemoveFlow`.

--- a/_actions/RemoveSelectedOverrides.md
+++ b/_actions/RemoveSelectedOverrides.md
@@ -1,8 +1,6 @@
 ---
 title: RemoveSelectedOverrides
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the RemoveSelectedOverrides action will appear here.
+No details available for `RemoveSelectedOverrides`.

--- a/_actions/RemoveTextTransform.md
+++ b/_actions/RemoveTextTransform.md
@@ -1,8 +1,6 @@
 ---
 title: RemoveTextTransform
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the RemoveTextTransform action will appear here.
+No details available for `RemoveTextTransform`.

--- a/_actions/RemoveUnusedStyles.md
+++ b/_actions/RemoveUnusedStyles.md
@@ -1,8 +1,6 @@
 ---
 title: RemoveUnusedStyles
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the RemoveUnusedStyles action will appear here.
+No details available for `RemoveUnusedStyles`.

--- a/_actions/RenameLayer.md
+++ b/_actions/RenameLayer.md
@@ -1,8 +1,6 @@
 ---
 title: RenameLayer
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the RenameLayer action will appear here.
+No details available for `RenameLayer`.

--- a/_actions/ReplaceColor.md
+++ b/_actions/ReplaceColor.md
@@ -1,8 +1,6 @@
 ---
 title: ReplaceColor
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ReplaceColor action will appear here.
+No details available for `ReplaceColor`.

--- a/_actions/ReplaceFonts.md
+++ b/_actions/ReplaceFonts.md
@@ -1,8 +1,6 @@
 ---
 title: ReplaceFonts
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ReplaceFonts action will appear here.
+No details available for `ReplaceFonts`.

--- a/_actions/ReplaceImage.md
+++ b/_actions/ReplaceImage.md
@@ -1,8 +1,6 @@
 ---
 title: ReplaceImage
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ReplaceImage action will appear here.
+No details available for `ReplaceImage`.

--- a/_actions/ReplaceOverride.md
+++ b/_actions/ReplaceOverride.md
@@ -1,8 +1,6 @@
 ---
 title: ReplaceOverride
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ReplaceOverride action will appear here.
+No details available for `ReplaceOverride`.

--- a/_actions/ReplaceOverrideStyle.md
+++ b/_actions/ReplaceOverrideStyle.md
@@ -1,8 +1,6 @@
 ---
 title: ReplaceOverrideStyle
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ReplaceOverrideStyle action will appear here.
+No details available for `ReplaceOverrideStyle`.

--- a/_actions/ReplaceOverrideSymbol.md
+++ b/_actions/ReplaceOverrideSymbol.md
@@ -1,8 +1,6 @@
 ---
 title: ReplaceOverrideSymbol
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ReplaceOverrideSymbol action will appear here.
+No details available for `ReplaceOverrideSymbol`.

--- a/_actions/ReplaceWithSymbol.md
+++ b/_actions/ReplaceWithSymbol.md
@@ -1,8 +1,6 @@
 ---
 title: ReplaceWithSymbol
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ReplaceWithSymbol action will appear here.
+No details available for `ReplaceWithSymbol`.

--- a/_actions/ReplaceWithSymbolRoot.md
+++ b/_actions/ReplaceWithSymbolRoot.md
@@ -1,8 +1,6 @@
 ---
 title: ReplaceWithSymbolRoot
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ReplaceWithSymbolRoot action will appear here.
+No details available for `ReplaceWithSymbolRoot`.

--- a/_actions/ResetBoolean.md
+++ b/_actions/ResetBoolean.md
@@ -1,8 +1,0 @@
----
-title: ResetBoolean
-summary: work in progress
----
-
-Work In Progress
-
-Documentation for the ResetBoolean action will appear here.

--- a/_actions/ResetOrigin.md
+++ b/_actions/ResetOrigin.md
@@ -1,8 +1,6 @@
 ---
 title: ResetOrigin
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ResetOrigin action will appear here.
+No details available for `ResetOrigin`.

--- a/_actions/ResetSharedColor.md
+++ b/_actions/ResetSharedColor.md
@@ -1,0 +1,6 @@
+---
+title: ResetSharedColor
+summary:
+---
+
+No details available for `ResetSharedColor`.

--- a/_actions/ResetSharedStyle.md
+++ b/_actions/ResetSharedStyle.md
@@ -1,8 +1,6 @@
 ---
 title: ResetSharedStyle
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ResetSharedStyle action will appear here.
+No details available for `ResetSharedStyle`.

--- a/_actions/ResetSymbolSize.md
+++ b/_actions/ResetSymbolSize.md
@@ -1,8 +1,6 @@
 ---
 title: ResetSymbolSize
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ResetSymbolSize action will appear here.
+No details available for `ResetSymbolSize`.

--- a/_actions/ResizeArtboardToFit.md
+++ b/_actions/ResizeArtboardToFit.md
@@ -1,8 +1,6 @@
 ---
 title: ResizeArtboardToFit
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ResizeArtboardToFit action will appear here.
+No details available for `ResizeArtboardToFit`.

--- a/_actions/RevealInLayerList.md
+++ b/_actions/RevealInLayerList.md
@@ -1,8 +1,6 @@
 ---
 title: RevealInLayerList
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the RevealInLayerList action will appear here.
+No details available for `RevealInLayerList`.

--- a/_actions/ReversePath.md
+++ b/_actions/ReversePath.md
@@ -1,8 +1,6 @@
 ---
 title: ReversePath
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ReversePath action will appear here.
+No details available for `ReversePath`.

--- a/_actions/Rotate.md
+++ b/_actions/Rotate.md
@@ -1,8 +1,6 @@
 ---
 title: Rotate
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the Rotate action will appear here.
+No details available for `Rotate`.

--- a/_actions/RotateClockwise.md
+++ b/_actions/RotateClockwise.md
@@ -1,8 +1,6 @@
 ---
 title: RotateClockwise
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the RotateClockwise action will appear here.
+No details available for `RotateClockwise`.

--- a/_actions/RotateCounterclockwise.md
+++ b/_actions/RotateCounterclockwise.md
@@ -1,8 +1,6 @@
 ---
 title: RotateCounterclockwise
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the RotateCounterclockwise action will appear here.
+No details available for `RotateCounterclockwise`.

--- a/_actions/RoundToPixel.md
+++ b/_actions/RoundToPixel.md
@@ -1,8 +1,6 @@
 ---
 title: RoundToPixel
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the RoundToPixel action will appear here.
+No details available for `RoundToPixel`.

--- a/_actions/RoundedRectangleShape.md
+++ b/_actions/RoundedRectangleShape.md
@@ -1,8 +1,6 @@
 ---
 title: RoundedRectangleShape
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the RoundedRectangleShape action will appear here.
+No details available for `RoundedRectangleShape`.

--- a/_actions/RunPluginCommand.md
+++ b/_actions/RunPluginCommand.md
@@ -1,8 +1,6 @@
 ---
 title: RunPluginCommand
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the RunPluginCommand action will appear here.
+No details available for `RunPluginCommand`.

--- a/_actions/SaveAsTemplate.md
+++ b/_actions/SaveAsTemplate.md
@@ -1,8 +1,6 @@
 ---
 title: SaveAsTemplate
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the SaveAsTemplate action will appear here.
+No details available for `SaveAsTemplate`.

--- a/_actions/Scale.md
+++ b/_actions/Scale.md
@@ -1,8 +1,6 @@
 ---
 title: Scale
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the Scale action will appear here.
+No details available for `Scale`.

--- a/_actions/Scissors.md
+++ b/_actions/Scissors.md
@@ -1,8 +1,6 @@
 ---
 title: Scissors
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the Scissors action will appear here.
+No details available for `Scissors`.

--- a/_actions/Search.md
+++ b/_actions/Search.md
@@ -1,0 +1,6 @@
+---
+title: Search
+summary:
+---
+
+No details available for `Search`.

--- a/_actions/SelectAll.md
+++ b/_actions/SelectAll.md
@@ -1,8 +1,6 @@
 ---
 title: SelectAll
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the SelectAll action will appear here.
+No details available for `SelectAll`.

--- a/_actions/SelectAllArtboards.md
+++ b/_actions/SelectAllArtboards.md
@@ -1,8 +1,6 @@
 ---
 title: SelectAllArtboards
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the SelectAllArtboards action will appear here.
+No details available for `SelectAllArtboards`.

--- a/_actions/SelectAllInArtboard.md
+++ b/_actions/SelectAllInArtboard.md
@@ -1,8 +1,0 @@
----
-title: SelectAllInArtboard
-summary: work in progress
----
-
-Work In Progress
-
-Documentation for the SelectAllInArtboard action will appear here.

--- a/_actions/SendToSymbolsPage.md
+++ b/_actions/SendToSymbolsPage.md
@@ -1,8 +1,6 @@
 ---
 title: SendToSymbolsPage
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the SendToSymbolsPage action will appear here.
+No details available for `SendToSymbolsPage`.

--- a/_actions/Shape.md
+++ b/_actions/Shape.md
@@ -1,8 +1,6 @@
 ---
 title: Shape
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the Shape action will appear here.
+No details available for `Shape`.

--- a/_actions/ShowBorderOptions.md
+++ b/_actions/ShowBorderOptions.md
@@ -1,8 +1,6 @@
 ---
 title: ShowBorderOptions
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ShowBorderOptions action will appear here.
+No details available for `ShowBorderOptions`.

--- a/_actions/ShowColors.md
+++ b/_actions/ShowColors.md
@@ -1,8 +1,6 @@
 ---
 title: ShowColors
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ShowColors action will appear here.
+No details available for `ShowColors`.

--- a/_actions/ShowComponentsPane.md
+++ b/_actions/ShowComponentsPane.md
@@ -1,8 +1,6 @@
 ---
 title: ShowComponentsPane
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ShowComponentsPane action will appear here.
+No details available for `ShowComponentsPane`.

--- a/_actions/ShowDocumentFonts.md
+++ b/_actions/ShowDocumentFonts.md
@@ -1,8 +1,6 @@
 ---
 title: ShowDocumentFonts
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ShowDocumentFonts action will appear here.
+No details available for `ShowDocumentFonts`.

--- a/_actions/ShowFillOptions.md
+++ b/_actions/ShowFillOptions.md
@@ -1,8 +1,6 @@
 ---
 title: ShowFillOptions
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ShowFillOptions action will appear here.
+No details available for `ShowFillOptions`.

--- a/_actions/ShowFonts.md
+++ b/_actions/ShowFonts.md
@@ -1,8 +1,6 @@
 ---
 title: ShowFonts
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ShowFonts action will appear here.
+No details available for `ShowFonts`.

--- a/_actions/ShowLayerList.md
+++ b/_actions/ShowLayerList.md
@@ -1,8 +1,6 @@
 ---
 title: ShowLayerList
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ShowLayerList action will appear here.
+No details available for `ShowLayerList`.

--- a/_actions/ShowReplaceColorSheet.md
+++ b/_actions/ShowReplaceColorSheet.md
@@ -1,8 +1,6 @@
 ---
 title: ShowReplaceColorSheet
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ShowReplaceColorSheet action will appear here.
+No details available for `ShowReplaceColorSheet`.

--- a/_actions/Sketch.MSAddComponent.md
+++ b/_actions/Sketch.MSAddComponent.md
@@ -1,0 +1,6 @@
+---
+title: Sketch.MSAddComponent
+summary:
+---
+
+No details available for `Sketch.MSAddComponent`.

--- a/_actions/Sketch.MSChangeComponentKindActionGroup.md
+++ b/_actions/Sketch.MSChangeComponentKindActionGroup.md
@@ -1,0 +1,6 @@
+---
+title: Sketch.MSChangeComponentKindActionGroup
+summary:
+---
+
+No details available for `Sketch.MSChangeComponentKindActionGroup`.

--- a/_actions/Sketch.MSChangeLayerStyleComponentKind.md
+++ b/_actions/Sketch.MSChangeLayerStyleComponentKind.md
@@ -1,0 +1,6 @@
+---
+title: Sketch.MSChangeLayerStyleComponentKind
+summary:
+---
+
+No details available for `Sketch.MSChangeLayerStyleComponentKind`.

--- a/_actions/Sketch.MSChangeSwatchComponentKind.md
+++ b/_actions/Sketch.MSChangeSwatchComponentKind.md
@@ -1,0 +1,6 @@
+---
+title: Sketch.MSChangeSwatchComponentKind
+summary:
+---
+
+No details available for `Sketch.MSChangeSwatchComponentKind`.

--- a/_actions/Sketch.MSChangeSymbolComponentKind.md
+++ b/_actions/Sketch.MSChangeSymbolComponentKind.md
@@ -1,0 +1,6 @@
+---
+title: Sketch.MSChangeSymbolComponentKind
+summary:
+---
+
+No details available for `Sketch.MSChangeSymbolComponentKind`.

--- a/_actions/Sketch.MSChangeTextStyleComponentKind.md
+++ b/_actions/Sketch.MSChangeTextStyleComponentKind.md
@@ -1,0 +1,6 @@
+---
+title: Sketch.MSChangeTextStyleComponentKind
+summary:
+---
+
+No details available for `Sketch.MSChangeTextStyleComponentKind`.

--- a/_actions/Sketch.MSComponentsPicker.md
+++ b/_actions/Sketch.MSComponentsPicker.md
@@ -1,0 +1,6 @@
+---
+title: Sketch.MSComponentsPicker
+summary:
+---
+
+No details available for `Sketch.MSComponentsPicker`.

--- a/_actions/Sketch.MSContentMode.md
+++ b/_actions/Sketch.MSContentMode.md
@@ -1,0 +1,6 @@
+---
+title: Sketch.MSContentMode
+summary:
+---
+
+No details available for `Sketch.MSContentMode`.

--- a/_actions/Sketch.MSCopyComponent.md
+++ b/_actions/Sketch.MSCopyComponent.md
@@ -1,8 +1,6 @@
 ---
 title: Sketch.MSCopyComponent
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the Sketch.MSCopyComponent action will appear here.
+No details available for `Sketch.MSCopyComponent`.

--- a/_actions/Sketch.MSDeleteComponent.md
+++ b/_actions/Sketch.MSDeleteComponent.md
@@ -1,8 +1,6 @@
 ---
 title: Sketch.MSDeleteComponent
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the Sketch.MSDeleteComponent action will appear here.
+No details available for `Sketch.MSDeleteComponent`.

--- a/_actions/Sketch.MSDuplicateComponent.md
+++ b/_actions/Sketch.MSDuplicateComponent.md
@@ -1,8 +1,6 @@
 ---
 title: Sketch.MSDuplicateComponent
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the Sketch.MSDuplicateComponent action will appear here.
+No details available for `Sketch.MSDuplicateComponent`.

--- a/_actions/Sketch.MSEditSymbolMasterComponent.md
+++ b/_actions/Sketch.MSEditSymbolMasterComponent.md
@@ -1,8 +1,6 @@
 ---
 title: Sketch.MSEditSymbolMasterComponent
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the Sketch.MSEditSymbolMasterComponent action will appear here.
+No details available for `Sketch.MSEditSymbolMasterComponent`.

--- a/_actions/Sketch.MSFilterComponentList.md
+++ b/_actions/Sketch.MSFilterComponentList.md
@@ -1,8 +1,6 @@
 ---
 title: Sketch.MSFilterComponentList
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the Sketch.MSFilterComponentList action will appear here.
+No details available for `Sketch.MSFilterComponentList`.

--- a/_actions/Sketch.MSGroupComponents.md
+++ b/_actions/Sketch.MSGroupComponents.md
@@ -1,8 +1,6 @@
 ---
 title: Sketch.MSGroupComponents
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the Sketch.MSGroupComponents action will appear here.
+No details available for `Sketch.MSGroupComponents`.

--- a/_actions/Sketch.MSInsertComponentInstance.md
+++ b/_actions/Sketch.MSInsertComponentInstance.md
@@ -1,0 +1,6 @@
+---
+title: Sketch.MSInsertComponentInstance
+summary:
+---
+
+No details available for `Sketch.MSInsertComponentInstance`.

--- a/_actions/Sketch.MSMaintainScrollPosition.md
+++ b/_actions/Sketch.MSMaintainScrollPosition.md
@@ -1,8 +1,6 @@
 ---
 title: Sketch.MSMaintainScrollPosition
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the Sketch.MSMaintainScrollPosition action will appear here.
+No details available for `Sketch.MSMaintainScrollPosition`.

--- a/_actions/Sketch.MSRenameComponent.md
+++ b/_actions/Sketch.MSRenameComponent.md
@@ -1,8 +1,6 @@
 ---
 title: Sketch.MSRenameComponent
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the Sketch.MSRenameComponent action will appear here.
+No details available for `Sketch.MSRenameComponent`.

--- a/_actions/Sketch.MSRenameSharedStyle.md
+++ b/_actions/Sketch.MSRenameSharedStyle.md
@@ -1,0 +1,6 @@
+---
+title: Sketch.MSRenameSharedStyle
+summary:
+---
+
+No details available for `Sketch.MSRenameSharedStyle`.

--- a/_actions/Sketch.MSRevealComponent.md
+++ b/_actions/Sketch.MSRevealComponent.md
@@ -1,8 +1,6 @@
 ---
 title: Sketch.MSRevealComponent
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the Sketch.MSRevealComponent action will appear here.
+No details available for `Sketch.MSRevealComponent`.

--- a/_actions/Sketch.MSRevealComponentPane.md
+++ b/_actions/Sketch.MSRevealComponentPane.md
@@ -1,8 +1,0 @@
----
-title: Sketch.MSRevealComponentPane
-summary: work in progress
----
-
-Work In Progress
-
-Documentation for the Sketch.MSRevealComponentPane action will appear here.

--- a/_actions/Sketch.MSRevealComponentsPanel.md
+++ b/_actions/Sketch.MSRevealComponentsPanel.md
@@ -1,0 +1,6 @@
+---
+title: Sketch.MSRevealComponentsPanel
+summary:
+---
+
+No details available for `Sketch.MSRevealComponentsPanel`.

--- a/_actions/Sketch.MSTidy.md
+++ b/_actions/Sketch.MSTidy.md
@@ -1,8 +1,6 @@
 ---
 title: Sketch.MSTidy
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the Sketch.MSTidy action will appear here.
+No details available for `Sketch.MSTidy`.

--- a/_actions/Sketch.MSUngroupComponents.md
+++ b/_actions/Sketch.MSUngroupComponents.md
@@ -1,8 +1,6 @@
 ---
 title: Sketch.MSUngroupComponents
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the Sketch.MSUngroupComponents action will appear here.
+No details available for `Sketch.MSUngroupComponents`.

--- a/_actions/Sketch.MSVisitSymbolComponent.md
+++ b/_actions/Sketch.MSVisitSymbolComponent.md
@@ -1,0 +1,6 @@
+---
+title: Sketch.MSVisitSymbolComponent
+summary:
+---
+
+No details available for `Sketch.MSVisitSymbolComponent`.

--- a/_actions/Sketch.ToggleLibraryListInComponentsPane.md
+++ b/_actions/Sketch.ToggleLibraryListInComponentsPane.md
@@ -1,8 +1,0 @@
----
-title: Sketch.ToggleLibraryListInComponentsPane
-summary: work in progress
----
-
-Work In Progress
-
-Documentation for the Sketch.ToggleLibraryListInComponentsPane action will appear here.

--- a/_actions/Sketch.ToggleLibraryListInComponentsPanel.md
+++ b/_actions/Sketch.ToggleLibraryListInComponentsPanel.md
@@ -1,0 +1,6 @@
+---
+title: Sketch.ToggleLibraryListInComponentsPanel
+summary:
+---
+
+No details available for `Sketch.ToggleLibraryListInComponentsPanel`.

--- a/_actions/SmartRotate.md
+++ b/_actions/SmartRotate.md
@@ -1,8 +1,6 @@
 ---
 title: SmartRotate
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the SmartRotate action will appear here.
+No details available for `SmartRotate`.

--- a/_actions/SpiralShape.md
+++ b/_actions/SpiralShape.md
@@ -1,8 +1,0 @@
----
-title: SpiralShape
-summary: work in progress
----
-
-Work In Progress
-
-Documentation for the SpiralShape action will appear here.

--- a/_actions/Split.md
+++ b/_actions/Split.md
@@ -1,8 +1,0 @@
----
-title: Split
-summary: work in progress
----
-
-Work In Progress
-
-Documentation for the Split action will appear here.

--- a/_actions/StarShape.md
+++ b/_actions/StarShape.md
@@ -1,8 +1,6 @@
 ---
 title: StarShape
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the StarShape action will appear here.
+No details available for `StarShape`.

--- a/_actions/Subtract.md
+++ b/_actions/Subtract.md
@@ -1,8 +1,6 @@
 ---
 title: Subtract
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the Subtract action will appear here.
+No details available for `Subtract`.

--- a/_actions/SyncLibrary.md
+++ b/_actions/SyncLibrary.md
@@ -1,8 +1,6 @@
 ---
 title: SyncLibrary
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the SyncLibrary action will appear here.
+No details available for `SyncLibrary`.

--- a/_actions/SyncLocalColor.md
+++ b/_actions/SyncLocalColor.md
@@ -1,0 +1,6 @@
+---
+title: SyncLocalColor
+summary:
+---
+
+No details available for `SyncLocalColor`.

--- a/_actions/SyncLocalStyle.md
+++ b/_actions/SyncLocalStyle.md
@@ -1,8 +1,6 @@
 ---
 title: SyncLocalStyle
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the SyncLocalStyle action will appear here.
+No details available for `SyncLocalStyle`.

--- a/_actions/SyncSharedStyle.md
+++ b/_actions/SyncSharedStyle.md
@@ -1,8 +1,0 @@
----
-title: SyncSharedStyle
-summary: work in progress
----
-
-Work In Progress
-
-Documentation for the SyncSharedStyle action will appear here.

--- a/_actions/TextAlignTouchBarGroup.md
+++ b/_actions/TextAlignTouchBarGroup.md
@@ -1,8 +1,6 @@
 ---
 title: TextAlignTouchBarGroup
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the TextAlignTouchBarGroup action will appear here.
+No details available for `TextAlignTouchBarGroup`.

--- a/_actions/TextOnPath.md
+++ b/_actions/TextOnPath.md
@@ -1,8 +1,6 @@
 ---
 title: TextOnPath
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the TextOnPath action will appear here.
+No details available for `TextOnPath`.

--- a/_actions/TextStyleTouchBar.md
+++ b/_actions/TextStyleTouchBar.md
@@ -1,8 +1,6 @@
 ---
 title: TextStyleTouchBar
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the TextStyleTouchBar action will appear here.
+No details available for `TextStyleTouchBar`.

--- a/_actions/ToggleAlignmentGuides.md
+++ b/_actions/ToggleAlignmentGuides.md
@@ -1,8 +1,6 @@
 ---
 title: ToggleAlignmentGuides
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ToggleAlignmentGuides action will appear here.
+No details available for `ToggleAlignmentGuides`.

--- a/_actions/ToggleArtboardShadow.md
+++ b/_actions/ToggleArtboardShadow.md
@@ -1,8 +1,6 @@
 ---
 title: ToggleArtboardShadow
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ToggleArtboardShadow action will appear here.
+No details available for `ToggleArtboardShadow`.

--- a/_actions/ToggleFixToViewport.md
+++ b/_actions/ToggleFixToViewport.md
@@ -1,8 +1,6 @@
 ---
 title: ToggleFixToViewport
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ToggleFixToViewport action will appear here.
+No details available for `ToggleFixToViewport`.

--- a/_actions/ToggleFlowInteraction.md
+++ b/_actions/ToggleFlowInteraction.md
@@ -1,8 +1,6 @@
 ---
 title: ToggleFlowInteraction
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ToggleFlowInteraction action will appear here.
+No details available for `ToggleFlowInteraction`.

--- a/_actions/ToggleGrid.md
+++ b/_actions/ToggleGrid.md
@@ -1,8 +1,6 @@
 ---
 title: ToggleGrid
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ToggleGrid action will appear here.
+No details available for `ToggleGrid`.

--- a/_actions/ToggleInspectorVisibility.md
+++ b/_actions/ToggleInspectorVisibility.md
@@ -1,8 +1,6 @@
 ---
 title: ToggleInspectorVisibility
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ToggleInspectorVisibility action will appear here.
+No details available for `ToggleInspectorVisibility`.

--- a/_actions/ToggleInterface.md
+++ b/_actions/ToggleInterface.md
@@ -1,8 +1,6 @@
 ---
 title: ToggleInterface
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ToggleInterface action will appear here.
+No details available for `ToggleInterface`.

--- a/_actions/ToggleLayerHighlight.md
+++ b/_actions/ToggleLayerHighlight.md
@@ -1,8 +1,6 @@
 ---
 title: ToggleLayerHighlight
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ToggleLayerHighlight action will appear here.
+No details available for `ToggleLayerHighlight`.

--- a/_actions/ToggleLayerListVisibility.md
+++ b/_actions/ToggleLayerListVisibility.md
@@ -1,8 +1,0 @@
----
-title: ToggleLayerListVisibility
-summary: work in progress
----
-
-Work In Progress
-
-Documentation for the ToggleLayerListVisibility action will appear here.

--- a/_actions/ToggleLayout.md
+++ b/_actions/ToggleLayout.md
@@ -1,8 +1,6 @@
 ---
 title: ToggleLayout
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ToggleLayout action will appear here.
+No details available for `ToggleLayout`.

--- a/_actions/TogglePixelGrid.md
+++ b/_actions/TogglePixelGrid.md
@@ -1,8 +1,6 @@
 ---
 title: TogglePixelGrid
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the TogglePixelGrid action will appear here.
+No details available for `TogglePixelGrid`.

--- a/_actions/TogglePixelLines.md
+++ b/_actions/TogglePixelLines.md
@@ -1,8 +1,6 @@
 ---
 title: TogglePixelLines
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the TogglePixelLines action will appear here.
+No details available for `TogglePixelLines`.

--- a/_actions/TogglePresentationMode.md
+++ b/_actions/TogglePresentationMode.md
@@ -1,8 +1,0 @@
----
-title: TogglePresentationMode
-summary: work in progress
----
-
-Work In Progress
-
-Documentation for the TogglePresentationMode action will appear here.

--- a/_actions/ToggleRulerDragLocking.md
+++ b/_actions/ToggleRulerDragLocking.md
@@ -1,8 +1,6 @@
 ---
 title: ToggleRulerDragLocking
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ToggleRulerDragLocking action will appear here.
+No details available for `ToggleRulerDragLocking`.

--- a/_actions/ToggleRulers.md
+++ b/_actions/ToggleRulers.md
@@ -1,8 +1,6 @@
 ---
 title: ToggleRulers
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ToggleRulers action will appear here.
+No details available for `ToggleRulers`.

--- a/_actions/ToggleSelection.md
+++ b/_actions/ToggleSelection.md
@@ -1,8 +1,6 @@
 ---
 title: ToggleSelection
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ToggleSelection action will appear here.
+No details available for `ToggleSelection`.

--- a/_actions/ToggleSidebarVisibility.md
+++ b/_actions/ToggleSidebarVisibility.md
@@ -1,8 +1,6 @@
 ---
 title: ToggleSidebarVisibility
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ToggleSidebarVisibility action will appear here.
+No details available for `ToggleSidebarVisibility`.

--- a/_actions/ToggleSliceInteraction.md
+++ b/_actions/ToggleSliceInteraction.md
@@ -1,8 +1,6 @@
 ---
 title: ToggleSliceInteraction
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ToggleSliceInteraction action will appear here.
+No details available for `ToggleSliceInteraction`.

--- a/_actions/ToggleToolbarVisibility.md
+++ b/_actions/ToggleToolbarVisibility.md
@@ -1,8 +1,6 @@
 ---
 title: ToggleToolbarVisibility
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ToggleToolbarVisibility action will appear here.
+No details available for `ToggleToolbarVisibility`.

--- a/_actions/ToolsMenu.md
+++ b/_actions/ToolsMenu.md
@@ -1,8 +1,6 @@
 ---
 title: ToolsMenu
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ToolsMenu action will appear here.
+No details available for `ToolsMenu`.

--- a/_actions/Transform.md
+++ b/_actions/Transform.md
@@ -1,8 +1,6 @@
 ---
 title: Transform
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the Transform action will appear here.
+No details available for `Transform`.

--- a/_actions/TriangleShape.md
+++ b/_actions/TriangleShape.md
@@ -1,8 +1,6 @@
 ---
 title: TriangleShape
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the TriangleShape action will appear here.
+No details available for `TriangleShape`.

--- a/_actions/Underline.md
+++ b/_actions/Underline.md
@@ -1,8 +1,6 @@
 ---
 title: Underline
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the Underline action will appear here.
+No details available for `Underline`.

--- a/_actions/Undo.md
+++ b/_actions/Undo.md
@@ -1,8 +1,6 @@
 ---
 title: Undo
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the Undo action will appear here.
+No details available for `Undo`.

--- a/_actions/Ungroup.md
+++ b/_actions/Ungroup.md
@@ -1,8 +1,6 @@
 ---
 title: Ungroup
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the Ungroup action will appear here.
+No details available for `Ungroup`.

--- a/_actions/Union.md
+++ b/_actions/Union.md
@@ -1,8 +1,6 @@
 ---
 title: Union
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the Union action will appear here.
+No details available for `Union`.

--- a/_actions/UnlinkAndSyncFromLibrary.md
+++ b/_actions/UnlinkAndSyncFromLibrary.md
@@ -1,8 +1,6 @@
 ---
 title: UnlinkAndSyncFromLibrary
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the UnlinkAndSyncFromLibrary action will appear here.
+No details available for `UnlinkAndSyncFromLibrary`.

--- a/_actions/UnlinkFromLibrary.md
+++ b/_actions/UnlinkFromLibrary.md
@@ -1,8 +1,6 @@
 ---
 title: UnlinkFromLibrary
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the UnlinkFromLibrary action will appear here.
+No details available for `UnlinkFromLibrary`.

--- a/_actions/UpdatePlugins.md
+++ b/_actions/UpdatePlugins.md
@@ -1,8 +1,6 @@
 ---
 title: UpdatePlugins
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the UpdatePlugins action will appear here.
+No details available for `UpdatePlugins`.

--- a/_actions/ViewDocumentInDocumentsWindow.md
+++ b/_actions/ViewDocumentInDocumentsWindow.md
@@ -1,8 +1,6 @@
 ---
 title: ViewDocumentInDocumentsWindow
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ViewDocumentInDocumentsWindow action will appear here.
+No details available for `ViewDocumentInDocumentsWindow`.

--- a/_actions/ViewMenu.md
+++ b/_actions/ViewMenu.md
@@ -1,8 +1,6 @@
 ---
 title: ViewMenu
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ViewMenu action will appear here.
+No details available for `ViewMenu`.

--- a/_actions/ViewOnSketchCloudWeb.md
+++ b/_actions/ViewOnSketchCloudWeb.md
@@ -1,8 +1,6 @@
 ---
 title: ViewOnSketchCloudWeb
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ViewOnSketchCloudWeb action will appear here.
+No details available for `ViewOnSketchCloudWeb`.

--- a/_actions/Zoom.md
+++ b/_actions/Zoom.md
@@ -1,8 +1,6 @@
 ---
 title: Zoom
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the Zoom action will appear here.
+No details available for `Zoom`.

--- a/_actions/ZoomActions.md
+++ b/_actions/ZoomActions.md
@@ -1,8 +1,6 @@
 ---
 title: ZoomActions
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ZoomActions action will appear here.
+No details available for `ZoomActions`.

--- a/_actions/ZoomIn.md
+++ b/_actions/ZoomIn.md
@@ -1,8 +1,6 @@
 ---
 title: ZoomIn
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ZoomIn action will appear here.
+No details available for `ZoomIn`.

--- a/_actions/ZoomOut.md
+++ b/_actions/ZoomOut.md
@@ -1,8 +1,6 @@
 ---
 title: ZoomOut
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ZoomOut action will appear here.
+No details available for `ZoomOut`.

--- a/_actions/ZoomToActualSize.md
+++ b/_actions/ZoomToActualSize.md
@@ -1,8 +1,6 @@
 ---
 title: ZoomToActualSize
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ZoomToActualSize action will appear here.
+No details available for `ZoomToActualSize`.

--- a/_actions/ZoomToArtboard.md
+++ b/_actions/ZoomToArtboard.md
@@ -1,8 +1,6 @@
 ---
 title: ZoomToArtboard
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ZoomToArtboard action will appear here.
+No details available for `ZoomToArtboard`.

--- a/_actions/ZoomToSelection.md
+++ b/_actions/ZoomToSelection.md
@@ -1,8 +1,6 @@
 ---
 title: ZoomToSelection
-summary: work in progress
+summary:
 ---
 
-Work In Progress
-
-Documentation for the ZoomToSelection action will appear here.
+No details available for `ZoomToSelection`.


### PR DESCRIPTION
Note, merging into `release/69` to ensure nothing specific to Sketch 69 is deployed ahead of release.

- Removing misleading “Work in progress” copy. Detailed information is only provided for some actions.
- Fix https://github.com/sketch-hq/SketchAPI/issues/795