### PR TITLE
Update links to sketch-document

### DIFF
--- a/pages/assistants.md
+++ b/pages/assistants.md
@@ -23,7 +23,7 @@ Assistants…
 
 One of the fundamentals of Assistants is that they are defined per document. You can use certain Assistants with one document and others with another, for instance to work on multiple projects for different brands and respect their individual guidelines.
 
-> Documents specify Assistants as [dependencies](https://github.com/sketch-hq/sketch-file-format/blob/master/schema/objects/assistants-workspace.schema.yaml) in `*.sketch/workspace/assistants.json` similar to [JavaScript packages](https://docs.npmjs.com/files/package.json#dependencies). Sketch asks the user for permission to download missing Assistants when a document is checked and the specified version of an Assistant cannot be found locally.
+> Documents specify Assistants as dependencies in `*.sketch/workspace/assistants.json` similar to [JavaScript packages](https://docs.npmjs.com/files/package.json#dependencies). Sketch asks the user for permission to download missing Assistants when a document is checked and the specified version of an Assistant cannot be found locally.
 
 ## Create and publish Assistants
 

--- a/pages/file-format-json-schema.md
+++ b/pages/file-format-json-schema.md
@@ -3,7 +3,7 @@ title: JSON Schema
 section: file-format
 chapter: Resources
 redirect_from: /file-format/reference/json-schema
-redirect_to: https://github.com/sketch-hq/sketch-file-format
+redirect_to: https://github.com/sketch-hq/sketch-document/tree/main/packages/file-format
 order: 101
 excerpt: File Format JSON Schema
 ---

--- a/pages/file-format-specification.md
+++ b/pages/file-format-specification.md
@@ -15,12 +15,12 @@ Use the specification to build robust low level integrations of Sketch such as s
 
 ### JSON Schema
 
-The core specification is published as JSON Schema from the [sketch-file-format](https://github.com/sketch-hq/sketch-file-format) package.
+The core specification is published as JSON Schema from the [sketch-file-format](https://github.com/sketch-hq/sketch-document/tree/main/packages/file-format) package.
 
 Use the JSON Schema to generate types, GraphQL schemas and model code or validate Sketch documents you create and manipulate programmatically.
 
 ### TypeScript
 
-The TypeScript types are generated automatically from the JSON Schema, and published via the [sketch-file-format-ts](https://github.com/sketch-hq/sketch-file-format-ts) package.
+The TypeScript types are generated automatically from the JSON Schema, and published via the [sketch-file-format-ts](https://github.com/sketch-hq/sketch-document/tree/main/packages/file-format-ts) package.
 
 Use the types to strongly type data representing Sketch document objects, such as layers and artboards in TypeScript projects.

--- a/pages/file-format-typescript.md
+++ b/pages/file-format-typescript.md
@@ -4,5 +4,5 @@ section: file-format
 chapter: Resources
 order: 102
 redirect_from: /file-format/reference/typescript
-redirect_to: https://github.com/sketch-hq/sketch-file-format-ts
+redirect_to: https://github.com/sketch-hq/sketch-document/tree/main/packages/file-format-ts
 ---

--- a/pages/file-format-versioning.md
+++ b/pages/file-format-versioning.md
@@ -66,4 +66,4 @@ The earliest document `version` that a given version of Sketch can open.
 
 ## Version history
 
-See [sketch-file-format](https://github.com/sketch-hq/sketch-file-format/#sketch-document-version-mapping) documentation for information about how `appVersion` maps to document `version`.
+See [sketch-file-format](https://github.com/sketch-hq/sketch-document/tree/main/packages/file-format/#relationship-to-the-sketch-mac-application) documentation for information about how `appVersion` maps to document `version`.


### PR DESCRIPTION
Update links after moving file format related packages to https://github.com/sketch-hq/sketch-document monorepo.